### PR TITLE
Fix SIGSEGV in receive

### DIFF
--- a/rabbitmq.go
+++ b/rabbitmq.go
@@ -111,7 +111,7 @@ func (sub *RabbitMQSubscription) Receive() (amqp.Delivery, error) {
 			return msg, nil
 		}
 	}
-	if sub.mq.closed || sub.con.IsClosed() {
+	if sub.mq == nil || sub.mq.closed || sub.con == nil || sub.con.IsClosed() {
 		return amqp.Delivery{}, fmt.Errorf("EOF")
 	}
 	return amqp.Delivery{}, fmt.Errorf("channel unexpectedly closed")


### PR DESCRIPTION
Fix a nasty SIGSEGV in Receive if RabbitMQ was closed.

Fixes https://github.com/grisu48/gopenqa/issues/19