### PR TITLE
Introduce JobState

### DIFF
--- a/gopenqa.go
+++ b/gopenqa.go
@@ -445,6 +445,12 @@ fetch:
 	return job, err
 }
 
+// GetJobState uses the (currently experimental) API call to quickly fetch a job state
+func (i *Instance) GetJobState(id int64) (JobState, error) {
+	url := fmt.Sprintf("%s/api/v1//experimental/jobs/%d/status", i.URL, id)
+	return i.fetchJobState(url)
+}
+
 func (i *Instance) GetJobGroups() ([]JobGroup, error) {
 	url := fmt.Sprintf("%s/api/v1/job_groups", i.URL)
 	return i.fetchJobGroups(url)
@@ -617,6 +623,16 @@ func (i *Instance) fetchJob(url string) (Job, error) {
 	// TODO: Sometimes SizeLimit is returned as string but it should be an int. Fix this.
 	err = json.Unmarshal(resp, &job)
 	return job.Job, err
+}
+
+func (i *Instance) fetchJobState(url string) (JobState, error) {
+	var state JobState
+	resp, err := i.get(url, nil)
+	if err != nil {
+		return state, err
+	}
+	err = json.Unmarshal(resp, &state)
+	return state, err
 }
 
 /* merge given parameter string to URL parameters */

--- a/job.go
+++ b/job.go
@@ -42,6 +42,13 @@ type Settings struct {
 	Machine string `json:"MACHINE"`
 }
 
+/* Special struct for getting quick job status */
+type JobState struct {
+	BlockedBy int64  `json:"blocked_by_id"`
+	Result    string `json:"result"`
+	State     string `json:"state"`
+}
+
 /* Format job as a string */
 func (j *Job) String() string {
 	return fmt.Sprintf("%d %s (%s)", j.ID, j.Name, j.Test)


### PR DESCRIPTION
Introduce the new JobState struct and a call GetJobState to fetch the job state using the new experimental low-profile API call.